### PR TITLE
Updating Schema Dataflow

### DIFF
--- a/02_Dataflow/Schemas/iotToBigQuery.json
+++ b/02_Dataflow/Schemas/iotToBigQuery.json
@@ -1,0 +1,24 @@
+{
+    "fields": [
+    {
+      "mode": "NULLABLE",
+      "name": "device_id",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "timeStamp",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "client_id",
+      "type": "STRING"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "kw",
+      "type": "NUMERIC"
+    }
+    ]
+}


### PR DESCRIPTION
El esquema es necesario, ya que la tabla de salida debe existir antes de ejecutar la canalización, el esquema de la tabla debe coincidir con los objetos JSON de entrada