### PR TITLE
Generar timestamp sin añadir zona horaria

### DIFF
--- a/01_Generador/generator.py
+++ b/01_Generador/generator.py
@@ -57,7 +57,7 @@ def generateMockData(client_id, device_id, name):
         "client_id": client_id,
         "device_name": name,
         "kw": str(random.randint(0, 1000)),
-        "timestamp": str(datetime.now(pytz.utc))
+        "timestamp": str(datetime.utcnow())
     }
 
 def run_generator(project_id, topic_name):


### PR DESCRIPTION
Ayer cuando estuve intentando conectar los datos en BigQuery con Data Studio, DataStudio no reconocía el formato del timestamp como válido. Después de investigar, encontré que era porque se estaba añadiendo la zona horaria al final (el +00:00) y DataStudio no acepta ese formatio: 

```
'2023-02-07 11:22:56.354536+00:00'
```

Con el cambio propuesto, seguimos generando el timestamp UTC, pero sin añadir la zona horaria:

```
'2023-02-07 11:22:56.354536'
```

@jusahu @marinapb16 antes de empezar a trabajar con DataStudio, deberíais borrar la tabla que tenemos en BigQuery, y luego mergear este PR y generar nuevos datos que tengan el tiempo bien formateado para que DataStudio lo reconozca