### PR TITLE
Generar los mismos device_id y client_id cada vez que ejecutemos el generador

### DIFF
--- a/01_Generador/generator.py
+++ b/01_Generador/generator.py
@@ -21,6 +21,11 @@ parser.add_argument(
                 '--topic_name',
                 required=True,
                 help='PubSub topic name.')
+parser.add_argument(
+                '--client_id',
+                required=False,
+                default='1',
+                help='Client ID to use in PubSub messages.')
 
 args, opts = parser.parse_known_args()
 
@@ -65,19 +70,21 @@ def run_generator(project_id, topic_name):
     #Publish message into the queue every 5 seconds
     clients = { }
 
-    num_clients = 5
+    # num_clients = 5
     num_devices = 5
 
 
-    for i in range (0, num_clients):
-        client_id = str(uuid.uuid4())
-        clients[client_id] = []
-        for n in range (0, num_devices):
-            device_id = str(uuid.uuid4())
-            clients[client_id].append((device_id, lista_devices[n]))
-    print(clients)
-    try:
+    # for i in range (0, num_clients):
+    client_id = f"client_{args.client_id}"
+    clients[client_id] = []
 
+    for n in range(0, num_devices):
+        device_id = f"device_{n + 1}"
+        clients[client_id].append((device_id, lista_devices[n]))
+
+    print(clients)
+
+    try:
         while True:
             timestamp = datetime.utcnow()
             for client_id in clients:


### PR DESCRIPTION
Como acordamos ayer, vamos a generar datos para los mismos client IDs y device IDs, en vez de generar IDs de forma aleatoria cada vez que se ejecute el generador. 

Aparte de esto, ayer me di cuenta de que si intenamos generar datos para muchos clientes en un mismo generador, el proceso de generar datos  añade mucha latencia, y ya no se generan datos cada 1 segundo. Como esta latencia que se añade al generar datos es impredecible, creo que debemos generar datos solo para un cliente en un generador, y ejecutar varios generadores, para así asegurar que se mandan datos cada 1 segundo.

Para poder generar datos con los mismos client ID, el generador aceptará el client_id como parámetro. Si quisiéramos generar datos para dos clientes, tenemos que ejecutar primero en un terminal:

```
python generator.py --project_id psyched-freedom-376515  --topic_name consumption --client_id 1
```

Y para el segundo cliente:

```
python generator.py --project_id psyched-freedom-376515  --topic_name consumption --client_id 2
```

Si hubiera un tercero, en un nuevo terminal:

```
python generator.py --project_id psyched-freedom-376515  --topic_name consumption --client_id 3
```

Y lo mismo para más clientes. 